### PR TITLE
Update to 1.18.1 + fix beer crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
-version = project.mod_version
+version = project.mod_version + "-" + project.minecraft_version
 group = project.maven_group
 
 repositories {
@@ -46,8 +46,8 @@ tasks.withType(JavaCompile).configureEach {
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
 
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
+	it.options.release = 17
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.18
-	yayarn_mappings=1.18+build.1
-	loader_version=0.12.6
+	minecraft_version=1.18.1
+	yarn_mappings=1.18.1+build.22
+	loader_version=0.14.5
 
 # Mod Properties
-	mod_version = 3.0
+	mod_version = 3.1
 	maven_group = com.lekavar.lma.drinkbeer
 	archives_base_name = drinkbeer
 
 # Dependencies
-	fabric_version=0.43.1+1.18
+	fabric_version=0.46.6+1.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.14
-	loader_version=0.11.6
+	minecraft_version=1.18
+	yayarn_mappings=1.18+build.1
+	loader_version=0.12.6
 
 # Mod Properties
 	mod_version = 3.0
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = drinkbeer
 
 # Dependencies
-	fabric_version=0.37.0+1.17
+	fabric_version=0.43.1+1.18

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Aug 17 16:10:39 CST 2021
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/lekavar/lma/drinkbeer/block/BartendingTableBlock.java
+++ b/src/main/java/lekavar/lma/drinkbeer/block/BartendingTableBlock.java
@@ -2,7 +2,6 @@ package lekavar.lma.drinkbeer.block;
 
 import lekavar.lma.drinkbeer.DrinkBeer;
 import lekavar.lma.drinkbeer.block.entity.BartendingTableEntity;
-import lekavar.lma.drinkbeer.block.entity.BeerBarrelEntity;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.LivingEntity;

--- a/src/main/java/lekavar/lma/drinkbeer/block/entity/BartendingTableEntity.java
+++ b/src/main/java/lekavar/lma/drinkbeer/block/entity/BartendingTableEntity.java
@@ -68,8 +68,7 @@ public class BartendingTableEntity extends BlockEntity implements NamedScreenHan
     }
 
     @Override
-    public NbtCompound writeNbt(NbtCompound tag) {
-        super.writeNbt(tag);
+    public void writeNbt(NbtCompound tag) {
         //Write beerId
         tag.putShort("beerId", (short) this.beerId);
         //Write isMixedBeer
@@ -80,7 +79,7 @@ public class BartendingTableEntity extends BlockEntity implements NamedScreenHan
             tag.put("Spices", listTag);
         }
 
-        return tag;
+        super.writeNbt(tag);
     }
 
     @Override

--- a/src/main/java/lekavar/lma/drinkbeer/block/entity/BeerBarrelEntity.java
+++ b/src/main/java/lekavar/lma/drinkbeer/block/entity/BeerBarrelEntity.java
@@ -82,8 +82,7 @@ public class BeerBarrelEntity extends BlockEntity implements ImplementedInventor
     }
 
     @Override
-    public NbtCompound writeNbt(NbtCompound tag) {
-        super.writeNbt(tag);
+    public void writeNbt(NbtCompound tag) {
         Inventories.writeNbt(tag,inventory);
         tag.putShort("RemainingBrewTime", (short)this.remainingBrewingTime);
         tag.putShort("IsMaterialCompleted", (short)this.isMaterialCompleted);
@@ -91,7 +90,8 @@ public class BeerBarrelEntity extends BlockEntity implements ImplementedInventor
         tag.putShort("IsBrewing", (short)this.isBrewing);
         tag.putShort("BeerResultNum", (short)this.beerResultNum);
 
-        return tag;
+
+        super.writeNbt(tag);
     }
 
     @Override

--- a/src/main/java/lekavar/lma/drinkbeer/block/entity/MixedBeerEntity.java
+++ b/src/main/java/lekavar/lma/drinkbeer/block/entity/MixedBeerEntity.java
@@ -83,11 +83,6 @@ public class MixedBeerEntity extends BlockEntity {
     @Nullable
     @Override
     public BlockEntityUpdateS2CPacket toUpdatePacket() {
-        return new BlockEntityUpdateS2CPacket(this.pos, 6, this.toInitialChunkDataNbt());
-    }
-
-    @Override
-    public NbtCompound toInitialChunkDataNbt() {
-        return this.writeNbt((new NbtCompound()));
+        return BlockEntityUpdateS2CPacket.create(this);
     }
 }

--- a/src/main/java/lekavar/lma/drinkbeer/block/entity/MixedBeerEntity.java
+++ b/src/main/java/lekavar/lma/drinkbeer/block/entity/MixedBeerEntity.java
@@ -38,8 +38,8 @@ public class MixedBeerEntity extends BlockEntity {
     }
 
     @Override
-    public NbtCompound writeNbt(NbtCompound tag) {
-        super.writeNbt(tag);
+    public void writeNbt(NbtCompound tag) {
+        
         //Write beerId
         tag.putShort("beerId", (short) this.beerId);
 
@@ -49,7 +49,7 @@ public class MixedBeerEntity extends BlockEntity {
             tag.put("Spices", listTag);
         }
 
-        return tag;
+        super.writeNbt(tag);
     }
 
     @Override

--- a/src/main/java/lekavar/lma/drinkbeer/block/entity/MixedBeerEntity.java
+++ b/src/main/java/lekavar/lma/drinkbeer/block/entity/MixedBeerEntity.java
@@ -2,15 +2,12 @@ package lekavar.lma.drinkbeer.block.entity;
 
 import lekavar.lma.drinkbeer.DrinkBeer;
 import lekavar.lma.drinkbeer.manager.MixedBeerManager;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
-import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.Nullable;
 
@@ -69,7 +66,7 @@ public class MixedBeerEntity extends BlockEntity {
         }
     }
 
-    @Environment(EnvType.CLIENT)
+    // @Environment(EnvType.CLIENT)
     public ItemStack getPickStack(BlockState state) {
         //Generate mixed beer item stack for dropping
         ItemStack resultStack = MixedBeerManager.genMixedBeerItemStack(this.beerId, this.spiceList);

--- a/src/main/java/lekavar/lma/drinkbeer/manager/MixedBeerManager.java
+++ b/src/main/java/lekavar/lma/drinkbeer/manager/MixedBeerManager.java
@@ -16,7 +16,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.nbt.NbtHelper;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.world.World;
 

--- a/src/main/java/lekavar/lma/drinkbeer/manager/SpiceAndFlavorManager.java
+++ b/src/main/java/lekavar/lma/drinkbeer/manager/SpiceAndFlavorManager.java
@@ -4,7 +4,6 @@ import lekavar.lma.drinkbeer.util.mixedbeer.FlavorCombinations;
 import lekavar.lma.drinkbeer.util.mixedbeer.Flavors;
 import lekavar.lma.drinkbeer.util.mixedbeer.MixedBeerOnUsing;
 import lekavar.lma.drinkbeer.util.mixedbeer.Spices;
-import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.particle.DefaultParticleType;

--- a/src/main/java/lekavar/lma/drinkbeer/statuseffects/DrunkFrostWalkerStatusEffect.java
+++ b/src/main/java/lekavar/lma/drinkbeer/statuseffects/DrunkFrostWalkerStatusEffect.java
@@ -1,12 +1,10 @@
 package lekavar.lma.drinkbeer.statuseffects;
 
-import lekavar.lma.drinkbeer.DrinkBeer;
 import net.minecraft.enchantment.FrostWalkerEnchantment;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.AttributeContainer;
 import net.minecraft.entity.effect.StatusEffect;
-import net.minecraft.entity.effect.StatusEffectInstance;
-import net.minecraft.entity.effect.StatusEffectType;
+import net.minecraft.entity.effect.StatusEffectCategory;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 
@@ -14,7 +12,7 @@ import java.awt.*;
 
 public class DrunkFrostWalkerStatusEffect extends StatusEffect {
     public DrunkFrostWalkerStatusEffect() {
-        super(StatusEffectType.BENEFICIAL, new Color(30, 144, 255, 255).getRGB());
+        super(StatusEffectCategory.BENEFICIAL, new Color(30, 144, 255, 255).getRGB());
     }
 
     @Override

--- a/src/main/java/lekavar/lma/drinkbeer/statuseffects/DrunkStatusEffect.java
+++ b/src/main/java/lekavar/lma/drinkbeer/statuseffects/DrunkStatusEffect.java
@@ -3,8 +3,8 @@ package lekavar.lma.drinkbeer.statuseffects;
 import lekavar.lma.drinkbeer.DrinkBeer;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffectCategory;
 import net.minecraft.entity.effect.StatusEffectInstance;
-import net.minecraft.entity.effect.StatusEffectType;
 import net.minecraft.entity.effect.StatusEffects;
 
 import java.awt.*;
@@ -20,7 +20,7 @@ public class DrunkStatusEffect extends StatusEffect {
     private static final int[] harmulStatusEffectsIntervals = {200, 160, 200, 300, 20};
 
     public DrunkStatusEffect() {
-        super(StatusEffectType.HARMFUL, new Color(255, 222, 173, 255).getRGB());
+        super(StatusEffectCategory.HARMFUL, new Color(255, 222, 173, 255).getRGB());
     }
 
     @Override

--- a/src/main/java/lekavar/lma/drinkbeer/util/mixedbeer/Spices.java
+++ b/src/main/java/lekavar/lma/drinkbeer/util/mixedbeer/Spices.java
@@ -1,13 +1,7 @@
 package lekavar.lma.drinkbeer.util.mixedbeer;
 
 import lekavar.lma.drinkbeer.DrinkBeer;
-import lekavar.lma.drinkbeer.util.beer.BrewingLeftover;
 import net.minecraft.item.Item;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 public enum Spices {
     BLAZE_PAPRIKA(1, DrinkBeer.SPICE_BLAZE_PAPRIKA.asItem(), Flavors.FIERY),

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,33 +1,27 @@
 {
   "schemaVersion": 1,
   "id": "drinkbeer",
-  "version": "3.0",
+  "version": "3.1",
 
   "name": "Drink Beer",
   "description": "Brewing placeable and drinkable beers in Minecraft!",
-  "authors": [
-    "Lekavar"
-  ],
-  "contact": {
-  },
+  "authors": ["Lekavar"],
+  "contact": {},
 
   "license": "GNU AFFERO GENERAL PUBLIC LICENSE version3.0",
   "icon": "assets/drinkbeer/icon.png",
 
   "environment": "*",
   "entrypoints": {
-    "main": [
-      "lekavar.lma.drinkbeer.DrinkBeer"
-    ],
-    "client": [
-      "lekavar.lma.drinkbeer.client.DrinkBeerClient"
-    ]
+    "main": ["lekavar.lma.drinkbeer.DrinkBeer"],
+    "client": ["lekavar.lma.drinkbeer.client.DrinkBeerClient"]
   },
 
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.13.3",
     "fabric": "*",
-    "java": ">=16"
+    "java": ">=17",
+    "minecraft": "~1.18.1"
   },
   "suggests": {
     "another-mod": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,6 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": "1.17.x",
     "java": ">=16"
   },
   "suggests": {


### PR DESCRIPTION
Related to #55. 

I updated the gradle and mod settings to 1.18, updated some of the code to match that version and also fixed a crash that would happen when placing/removing drinks.

So far this worked with a friend of mine on his tests. All I did was to comment out this section here on the MixedBeerEntity class:

![image](https://user-images.githubusercontent.com/10342701/182046962-996b89da-cea7-46b1-bdbb-4ee5f9b37c41.png)

I don't know why this function is set to be client-side in the first place, so I'd appreciate if anyone here knows what kind of problems this would cause.

For those who are having this issue (#55), try cloning off my branch and building the mod yourself to see if it works as expected. In case you're still on 1.17, use the 1.17 branch, modify the line I indicated above and build the mod.

